### PR TITLE
Add naive feedback highlight system

### DIFF
--- a/example/book.toml
+++ b/example/book.toml
@@ -6,3 +6,4 @@ src = "src"
 title = "example"
 
 [preprocessor.quiz]
+feedback = true

--- a/js/build.mjs
+++ b/js/build.mjs
@@ -78,7 +78,11 @@ async function main() {
   let p1 = build({
     format: "iife",
     bundle: true,
-    entryPoints: ["lib/entryPoints/embed.tsx", "lib/entryPoints/consent.tsx"],
+    entryPoints: [
+      "lib/entryPoints/embed.tsx",
+      "lib/entryPoints/consent.tsx",
+      "lib/entryPoints/feedback.tsx",
+    ],
     plugins: [copyPlugin({ extensions: [".html"] }), sassPlugin()],
   });
 

--- a/js/css/feedback.scss
+++ b/js/css/feedback.scss
@@ -106,6 +106,11 @@
     border-right: 1px solid var(--popper-bg-hover);
 }
 
+.modal-textarea-helper {
+    font-size: 0.75em;
+    color: #ff0033;
+}
+
 .ReactModal__Overlay {
     z-index: 101; // must be >= #menu-bar z-index
 }

--- a/js/css/feedback.scss
+++ b/js/css/feedback.scss
@@ -1,8 +1,39 @@
+/* Theme */
+.ayu {
+    --popper-bg: var(--quote-bg);
+    --popper-bg-hover: #1D1F21;
+    --popper-color: var(--fg);
+}
+
+.coal {
+    --popper-bg: var(--quote-bg);
+    --popper-bg-hover: #1D1F21;
+    --popper-color: var(--fg);
+}
+
+.light {
+    --popper-bg: #262625;
+    --popper-bg-hover: #aaaaaa;
+    --popper-color: white;
+}
+
+.navy {
+    --popper-bg: var(--quote-bg);
+    --popper-bg-hover: #1D1F21;
+    --popper-color: var(--fg);
+}
+
+.rust {
+    --popper-bg: var(--quote-bg);
+    --popper-bg-hover: #aaaaaa;
+    --popper-color: var(--fg);
+}
+
 .pop {
-    background-color: #262625;
+    background-color: var(--popper-bg);
+    color: var(--popper-color);
     border-radius: 5px;
     padding: 10px;
-    color: white;
     display: inline-block;
 }
 
@@ -49,12 +80,16 @@
 
     // make emojis white
     color: transparent;
-    text-shadow: 0 0 0 white;
+    text-shadow: 0 0 0 var(--popper-color);
 
     // prevent text cursor when hovering over emoji
     cursor: pointer;
 }
 
 .pop-button:hover {
-    background-color: #4d4d49;
+    background-color: var(--popper-bg-hover);
+}
+
+.ReactModal__Overlay {
+    z-index: 101; // must be >= #menu-bar z-index
 }

--- a/js/css/feedback.scss
+++ b/js/css/feedback.scss
@@ -1,0 +1,53 @@
+.pop {
+    background-color: #262625;
+    border-radius: 5px;
+    padding: 10px;
+    color: white;
+    display: inline-block;
+}
+
+.pop-arrow,
+.pop-arrow::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: inherit;
+}
+
+.pop-arrow {
+    visibility: hidden;
+}
+
+.pop-arrow::before {
+    visibility: visible;
+    content: '';
+    transform: rotate(45deg);
+}
+
+.pop[data-popper-placement^='top'] > .pop-arrow {
+    bottom: -4px;
+}
+
+.pop[data-popper-placement^='bottom'] > .pop-arrow {
+    top: -4px;
+}
+
+.pop[data-popper-placement^='left'] > .pop-arrow {
+    right: -4px;
+}
+
+.pop[data-popper-placement^='right'] > .pop-arrow {
+    left: -4px;
+}
+
+.pop-button {
+    -moz-transition: all .1s ease-in;
+    -o-transition: all .1s ease-in;
+    -webkit-transition: all .1s ease-in;
+    transition: all .1s ease-in;
+    padding: 5px 10px;
+}
+
+.pop-button:hover {
+    background-color: #4d4d49;
+}

--- a/js/css/feedback.scss
+++ b/js/css/feedback.scss
@@ -45,7 +45,14 @@
     -o-transition: all .1s ease-in;
     -webkit-transition: all .1s ease-in;
     transition: all .1s ease-in;
-    padding: 5px 10px;
+    padding: 5px 8px;
+
+    // make emojis white
+    color: transparent;
+    text-shadow: 0 0 0 white;
+
+    // prevent text cursor when hovering over emoji
+    cursor: pointer;
 }
 
 .pop-button:hover {

--- a/js/css/feedback.scss
+++ b/js/css/feedback.scss
@@ -32,9 +32,14 @@
 .pop {
     background-color: var(--popper-bg);
     color: var(--popper-color);
-    border-radius: 5px;
     padding: 10px;
     display: inline-block;
+
+    // prevent tooltip dissapearing when cursor moves between
+    // highlight and tooltip
+    border-bottom: 8px solid transparent;
+    border-radius: 5px;
+    background-clip: padding-box;
 }
 
 .pop-arrow,
@@ -88,6 +93,17 @@
 
 .pop-button:hover {
     background-color: var(--popper-bg-hover);
+}
+
+.pop-feedback-container {
+    display: grid;
+    grid-template-columns: auto auto auto auto;
+    align-items: center;
+}
+
+.pop-feedback-text {
+    padding-right: 0.5rem;
+    border-right: 1px solid var(--popper-bg-hover);
 }
 
 .ReactModal__Overlay {

--- a/js/lib/components/feedback/modal.tsx
+++ b/js/lib/components/feedback/modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef } from "react";
 import Modal from "react-modal";
 import Highlighter from "web-highlighter";
 
@@ -15,31 +15,26 @@ const modalStyles = {
   },
 };
 
-type FeedbackModalProps = { range: Range; highlighter: Highlighter; toggleModal: () => void };
-const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, toggleModal }) => {
-  const [feedback, setFeedback] = useState("");
-
-  const handleFeedbackChange = (e: React.FormEvent<HTMLTextAreaElement>) => {
-    setFeedback(e.currentTarget.value);
-  };
+type FeedbackModalProps = { range: Range; highlighter: Highlighter; closeModal: () => void };
+const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, closeModal }) => {
+  const feedback = useRef<HTMLTextAreaElement>(null);
 
   const handleSubmit = () => {
     // add feedback to serialized highlighter data (dispose hook after use)
-    let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() => feedback);
+    let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() => feedback.current!.value);
     highlighter.fromRange(range);
     dispose();
 
-    toggleModal();
+    closeModal();
   };
 
   return (
-    <Modal style={modalStyles} contentLabel="Feedback Modal" onRequestClose={toggleModal} isOpen>
+    <Modal style={modalStyles} contentLabel="Feedback Modal" onRequestClose={closeModal} isOpen>
       <textarea
+        ref={feedback}
         style={{ minWidth: "250px" }}
         rows={4}
         placeholder="Your feedback..."
-        value={feedback}
-        onChange={handleFeedbackChange}
       ></textarea>
       <br />
       <button onClick={handleSubmit}>Submit</button>

--- a/js/lib/components/feedback/modal.tsx
+++ b/js/lib/components/feedback/modal.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import Modal from "react-modal";
+import Highlighter from "web-highlighter";
+
+Modal.setAppElement("body");
+
+const modalStyles = {
+  content: {
+    top: "50%",
+    left: "50%",
+    right: "auto",
+    bottom: "auto",
+    marginRight: "-50%",
+    transform: "translate(-50%, -50%)",
+  },
+};
+
+type FeedbackModalProps = { range: Range; highlighter: Highlighter; toggleModal: () => void };
+const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, toggleModal }) => {
+  const [feedback, setFeedback] = useState("");
+
+  const handleFeedbackChange = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    setFeedback(e.currentTarget.value);
+  };
+
+  const handleSubmit = () => {
+    // add feedback to serialized highlighter data
+    highlighter.hooks.Serialize.RecordInfo.tap(() => feedback);
+    highlighter.fromRange(range);
+    toggleModal();
+  };
+
+  return (
+    <Modal style={modalStyles} contentLabel="Feedback Modal" onRequestClose={toggleModal} isOpen>
+      <textarea
+        style={{ minWidth: "250px" }}
+        rows={4}
+        placeholder="Your feedback..."
+        value={feedback}
+        onChange={handleFeedbackChange}
+      ></textarea>
+      <br />
+      <button onClick={handleSubmit}>Submit</button>
+    </Modal>
+  );
+};
+
+export default FeedbackModal;

--- a/js/lib/components/feedback/modal.tsx
+++ b/js/lib/components/feedback/modal.tsx
@@ -24,9 +24,11 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, toggl
   };
 
   const handleSubmit = () => {
-    // add feedback to serialized highlighter data
-    highlighter.hooks.Serialize.RecordInfo.tap(() => feedback);
+    // add feedback to serialized highlighter data (dispose hook after use)
+    let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() => feedback);
     highlighter.fromRange(range);
+    dispose();
+
     toggleModal();
   };
 

--- a/js/lib/components/feedback/modal.tsx
+++ b/js/lib/components/feedback/modal.tsx
@@ -1,6 +1,8 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import Modal from "react-modal";
 import Highlighter from "web-highlighter";
+
+import "../../../css/feedback.scss";
 
 Modal.setAppElement("body");
 
@@ -18,8 +20,14 @@ const modalStyles = {
 type FeedbackModalProps = { range: Range; highlighter: Highlighter; closeModal: () => void };
 const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, closeModal }) => {
   const feedback = useRef<HTMLTextAreaElement>(null);
+  const [feedbackEmpty, setFeedbackEmpty] = useState(false);
 
   const handleSubmit = () => {
+    // prevent empty feedback submissions
+    if (!feedback.current!.value.trim()) {
+      return setFeedbackEmpty(true);
+    }
+
     // add feedback to serialized highlighter data (dispose hook after use)
     let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() => feedback.current!.value);
     highlighter.fromRange(range);
@@ -35,7 +43,9 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, close
         style={{ minWidth: "250px" }}
         rows={4}
         placeholder="Your feedback..."
+        required
       ></textarea>
+      {feedbackEmpty && <div className="modal-textarea-helper">Feedback is required</div>}
       <br />
       <button onClick={handleSubmit}>Submit</button>
     </Modal>

--- a/js/lib/components/feedback/renderer.tsx
+++ b/js/lib/components/feedback/renderer.tsx
@@ -1,0 +1,34 @@
+import { VirtualElement } from "@popperjs/core";
+import React from "react";
+import { useEffect, useState } from "react";
+import Highlighter from "web-highlighter";
+
+import SelectionTooltip from "./tooltip";
+
+type FeedbackRendererProps = { highlighter: Highlighter };
+const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
+  // id of feedback highlight currently hovered over
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  useEffect(() => {
+    // update state on hover changes
+    highlighter.on(Highlighter.event.HOVER, ({ id }) => setHovered(id));
+    highlighter.on(Highlighter.event.HOVER_OUT, () => setHovered(null));
+  }, []);
+
+  if (hovered) {
+    // If hovering over existing highlight, show feedback in tooltip
+    let el = highlighter.getDoms(hovered);
+    let feedback = highlighter.cache.get(hovered).extra as string;
+
+    const reference: VirtualElement = {
+      getBoundingClientRect: el[0].getBoundingClientRect.bind(el[0]),
+    };
+
+    return <SelectionTooltip reference={reference} text={feedback} />;
+  }
+
+  return null;
+};
+
+export default FeedbackRenderer;

--- a/js/lib/components/feedback/renderer.tsx
+++ b/js/lib/components/feedback/renderer.tsx
@@ -2,30 +2,61 @@ import { VirtualElement } from "@popperjs/core";
 import React from "react";
 import { useEffect, useState } from "react";
 import Highlighter from "web-highlighter";
+import HighlightSource from "web-highlighter/dist/model/source";
 
-import SelectionTooltip from "./tooltip";
+import { HIGHLIGHT_STORAGE_KEY } from "../../entryPoints/feedback";
+import FeedbackTooltip from "./tooltip";
 
 type FeedbackRendererProps = { highlighter: Highlighter };
 const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
-  // id of feedback highlight currently hovered over
-  const [hovered, setHovered] = useState<string | null>(null);
+  // id of feedback highlight and tooltip currently hovered over
+  const [highlightHovered, setHighlightHovered] = useState<string | null>(null);
+  const [tooltipHovered, setTooltipHovered] = useState<string | null>(null);
 
   useEffect(() => {
+    // remove highlights from local storage when deleted
+    highlighter.on(Highlighter.event.REMOVE, ({ ids }) => {
+      let stored_str = localStorage.getItem(HIGHLIGHT_STORAGE_KEY);
+      let stored_highlights = JSON.parse(stored_str || "[]") as HighlightSource[];
+      let filtered_highlights = stored_highlights.filter(hl => !ids.includes(hl.text));
+
+      localStorage.setItem(HIGHLIGHT_STORAGE_KEY, JSON.stringify(filtered_highlights));
+    });
+
     // update state on hover changes
-    highlighter.on(Highlighter.event.HOVER, ({ id }) => setHovered(id));
-    highlighter.on(Highlighter.event.HOVER_OUT, () => setHovered(null));
+    highlighter.on(Highlighter.event.HOVER, ({ id }) => setHighlightHovered(id));
+    highlighter.on(Highlighter.event.HOVER_OUT, () => setHighlightHovered(null));
   }, []);
 
-  if (hovered) {
-    // If hovering over existing highlight, show feedback in tooltip
-    let el = highlighter.getDoms(hovered);
-    let feedback = highlighter.cache.get(hovered).extra as string;
+  const removeFeedback = () => {
+    // cursor must be over tooltip when deleting, so use tooltip ID
+    highlighter.remove(tooltipHovered!);
+    setTooltipHovered(null);
+  };
+
+  // If hovering over existing highlight or tooltip, render tooltip
+  let id = highlightHovered || tooltipHovered;
+  if (id) {
+    let el = highlighter.getDoms(id);
+    let feedback = highlighter.cache.get(id).extra as string;
 
     const reference: VirtualElement = {
       getBoundingClientRect: el[0].getBoundingClientRect.bind(el[0]),
     };
 
-    return <SelectionTooltip reference={reference} text={feedback} />;
+    return (
+      <FeedbackTooltip
+        reference={reference}
+        onHoverChange={isHovered => setTooltipHovered(isHovered ? highlightHovered : null)}
+      >
+        <div className="pop-feedback-container">
+          <div className="pop-feedback-text">{feedback}</div>
+          <div className="pop-button" onClick={removeFeedback} title="Delete feedback">
+            &#128465;
+          </div>
+        </div>
+      </FeedbackTooltip>
+    );
   }
 
   return null;

--- a/js/lib/components/feedback/renderer.tsx
+++ b/js/lib/components/feedback/renderer.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import Highlighter from "web-highlighter";
 import HighlightSource from "web-highlighter/dist/model/source";
 
-import { HIGHLIGHT_STORAGE_KEY } from "../../entryPoints/feedback";
 import FeedbackTooltip from "./tooltip";
+import { HIGHLIGHT_STORAGE_KEY } from "./utils";
 
 type FeedbackRendererProps = { highlighter: Highlighter };
 const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {

--- a/js/lib/components/feedback/renderer.tsx
+++ b/js/lib/components/feedback/renderer.tsx
@@ -18,7 +18,7 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
     highlighter.on(Highlighter.event.REMOVE, ({ ids }) => {
       let stored_str = localStorage.getItem(HIGHLIGHT_STORAGE_KEY);
       let stored_highlights = JSON.parse(stored_str || "[]") as HighlightSource[];
-      let filtered_highlights = stored_highlights.filter(hl => !ids.includes(hl.text));
+      let filtered_highlights = stored_highlights.filter(hl => !ids.includes(hl.id));
 
       localStorage.setItem(HIGHLIGHT_STORAGE_KEY, JSON.stringify(filtered_highlights));
     });

--- a/js/lib/components/feedback/selection.tsx
+++ b/js/lib/components/feedback/selection.tsx
@@ -8,9 +8,6 @@ import SelectionTooltip from "./tooltip";
 
 type SelectionRendererProps = { highlighter: Highlighter; stored?: any[] };
 let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored }) => {
-  // id of feedback highlight currently being hovered over
-  const [hovered, setHovered] = useState<string | null>(null);
-
   // current highlighted range of text
   const [currRange, setCurrRange] = useState<Range | null>(null);
 
@@ -41,10 +38,6 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
 
       localStorage.setItem(HIGHLIGHT_STORAGE_KEY, JSON.stringify(stored_highlights));
     });
-
-    // update state on hover changes
-    highlighter.on(Highlighter.event.HOVER, ({ id }) => setHovered(id));
-    highlighter.on(Highlighter.event.HOVER_OUT, () => setHovered(null));
   }, []);
 
   useEffect(() => {
@@ -61,18 +54,6 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
     setModalOpen(false);
     setCurrRange(null);
   };
-
-  if (hovered) {
-    // If hovering over existing highlight, show feedback in tooltip
-    let el = highlighter.getDoms(hovered);
-    let feedback = highlighter.cache.get(hovered).extra as string;
-
-    const reference: VirtualElement = {
-      getBoundingClientRect: el[0].getBoundingClientRect.bind(el[0]),
-    };
-
-    return <SelectionTooltip reference={reference} text={feedback} />;
-  }
 
   if (currRange) {
     if (modalOpen) {

--- a/js/lib/components/feedback/selection.tsx
+++ b/js/lib/components/feedback/selection.tsx
@@ -1,0 +1,98 @@
+import { VirtualElement } from "@popperjs/core";
+import React, { useCallback, useEffect, useState } from "react";
+import Highlighter from "web-highlighter";
+
+import { HIGHLIGHT_STORAGE_KEY } from "../../entryPoints/feedback";
+import FeedbackModal from "./modal";
+import SelectionTooltip from "./tooltip";
+
+type SelectionRendererProps = { highlighter: Highlighter; stored: any[] | undefined };
+let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored }) => {
+  // id of feedback highlight currently being hovered over
+  const [hovered, setHovered] = useState<false | string>(false);
+
+  // current highlighted range of text
+  const [currRange, setCurrRange] = useState<false | Range>(false);
+
+  // whether feedback modal is open
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // update selected range when selection changes
+  const handleSelection = useCallback(() => {
+    // get current selection (falsy value if no selection)
+    let selection = document.getSelection();
+    let range =
+      selection && !selection.isCollapsed && selection.rangeCount && selection.getRangeAt(0);
+
+    if (range) {
+      setCurrRange(range);
+    } else {
+      setCurrRange(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // load highlights from local storage
+    stored?.map(s => highlighter.fromStore(s.startMeta, s.endMeta, s.id, s.text, s.extra));
+
+    // store new highlights in localStorage when created
+    highlighter.on(Highlighter.event.CREATE, ({ sources }) => {
+      let stored_str = localStorage.getItem(HIGHLIGHT_STORAGE_KEY);
+      let stored_highlights = JSON.parse(stored_str || "[]");
+      stored_highlights.push(...sources);
+
+      localStorage.setItem(HIGHLIGHT_STORAGE_KEY, JSON.stringify(stored_highlights));
+    });
+
+    // update state on hover changes
+    highlighter.on(Highlighter.event.HOVER, ({ id }) => setHovered(id));
+    highlighter.on(Highlighter.event.HOVER_OUT, () => setHovered(false));
+  }, []);
+
+  useEffect(() => {
+    // handle selection events only when modal closed
+    if (!modalOpen) {
+      document.addEventListener("selectionchange", handleSelection);
+    } else {
+      document.removeEventListener("selectionchange", handleSelection);
+    }
+  }, [modalOpen]);
+
+  // Remove modal and tooltip when closing modal
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setCurrRange(false);
+  };
+
+  if (hovered) {
+    // If hovering over existing highlight, show feedback in tooltip
+    let el = highlighter.getDoms(hovered);
+    let feedback = highlighter.cache.get(hovered).extra as string;
+
+    const reference: VirtualElement = {
+      getBoundingClientRect: el[0].getBoundingClientRect.bind(el[0]),
+    };
+
+    return <SelectionTooltip reference={reference} text={feedback} />;
+  }
+
+  if (currRange) {
+    if (modalOpen) {
+      // If tooltip feedback icon pressed, render modal
+      return (
+        <FeedbackModal range={currRange} highlighter={highlighter} toggleModal={handleCloseModal} />
+      );
+    } else {
+      // If modal not open, show tooltip over selected text
+      const reference: VirtualElement = {
+        getBoundingClientRect: currRange.getBoundingClientRect.bind(currRange),
+      };
+
+      return <SelectionTooltip reference={reference} toggleModal={() => setModalOpen(true)} />;
+    }
+  }
+
+  return <></>;
+};
+
+export default SelectionRenderer;

--- a/js/lib/components/feedback/selection.tsx
+++ b/js/lib/components/feedback/selection.tsx
@@ -4,7 +4,7 @@ import Highlighter from "web-highlighter";
 
 import { HIGHLIGHT_STORAGE_KEY } from "../../entryPoints/feedback";
 import FeedbackModal from "./modal";
-import SelectionTooltip from "./tooltip";
+import FeedbackTooltip from "./tooltip";
 
 type SelectionRendererProps = { highlighter: Highlighter; stored?: any[] };
 let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored }) => {
@@ -67,7 +67,17 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
         getBoundingClientRect: currRange.getBoundingClientRect.bind(currRange),
       };
 
-      return <SelectionTooltip reference={reference} openModal={() => setModalOpen(true)} />;
+      return (
+        <FeedbackTooltip reference={reference}>
+          <div
+            className="pop-button"
+            onClick={() => setModalOpen(true)}
+            title="Provide feedback on this content"
+          >
+            &#10068;
+          </div>
+        </FeedbackTooltip>
+      );
     }
   }
 

--- a/js/lib/components/feedback/selection.tsx
+++ b/js/lib/components/feedback/selection.tsx
@@ -2,9 +2,9 @@ import { VirtualElement } from "@popperjs/core";
 import React, { useCallback, useEffect, useState } from "react";
 import Highlighter from "web-highlighter";
 
-import { HIGHLIGHT_STORAGE_KEY } from "../../entryPoints/feedback";
 import FeedbackModal from "./modal";
 import FeedbackTooltip from "./tooltip";
+import { HIGHLIGHT_STORAGE_KEY } from "./utils";
 
 type SelectionRendererProps = { highlighter: Highlighter; stored?: any[] };
 let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored }) => {

--- a/js/lib/components/feedback/selection.tsx
+++ b/js/lib/components/feedback/selection.tsx
@@ -28,7 +28,7 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
 
   useEffect(() => {
     // load highlights from local storage
-    stored?.map(s => highlighter.fromStore(s.startMeta, s.endMeta, s.id, s.text, s.extra));
+    stored?.map(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id, s.extra));
 
     // store new highlights in localStorage when created
     highlighter.on(Highlighter.event.CREATE, ({ sources }) => {

--- a/js/lib/components/feedback/tooltip.tsx
+++ b/js/lib/components/feedback/tooltip.tsx
@@ -12,10 +12,10 @@ library.add(faQuestion);
 
 type SelectionTooltipProps = {
   reference: VirtualElement;
-  toggleModal?: () => void;
+  openModal?: () => void;
   text?: string;
 };
-const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, toggleModal, text }) => {
+const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, openModal, text }) => {
   const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
   const { styles, attributes } = usePopper(reference, popperElement, {
@@ -42,7 +42,7 @@ const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, toggleMo
       {text ? (
         <div>{text}</div>
       ) : (
-        <div className="pop-button" onClick={toggleModal} title="Provide feedback on this content">
+        <div className="pop-button" onClick={openModal} title="Provide feedback on this content">
           <FontAwesomeIcon icon="question" />
         </div>
       )}

--- a/js/lib/components/feedback/tooltip.tsx
+++ b/js/lib/components/feedback/tooltip.tsx
@@ -1,24 +1,31 @@
 import { VirtualElement } from "@popperjs/core";
-import React, { MouseEventHandler, useState } from "react";
+import React, { MouseEventHandler, PropsWithChildren, useEffect, useState } from "react";
 import { usePopper } from "react-popper";
 
 import "../../../css/feedback.scss";
 
-type SelectionTooltipProps = {
+type FeedbackTooltipProps = PropsWithChildren<{
   reference: VirtualElement;
-  openModal?: () => void;
-  text?: string;
-};
-const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, openModal, text }) => {
+  onHoverChange?: (isHovered: boolean) => void;
+}>;
+const FeedbackTooltip: React.FC<FeedbackTooltipProps> = ({
+  reference,
+  onHoverChange,
+  children,
+}) => {
   const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
   const { styles, attributes } = usePopper(reference, popperElement, {
     placement: "top",
-    modifiers: [
-      { name: "offset", options: { offset: [0, 8] } },
-      { name: "arrow", options: { element: arrowElement } },
-    ],
+    modifiers: [{ name: "arrow", options: { element: arrowElement } }],
   });
+
+  useEffect(() => {
+    if (onHoverChange && popperElement) {
+      popperElement.addEventListener("mouseenter", () => onHoverChange(true));
+      popperElement.addEventListener("mouseleave", () => onHoverChange(false));
+    }
+  }, [popperElement]);
 
   const handleTooltipClick: MouseEventHandler<HTMLDivElement> = ev => {
     // prevent loss of selected text when user clicks on tooltip
@@ -33,16 +40,10 @@ const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, openModa
       style={styles.popper}
       {...attributes.popper}
     >
-      {text ? (
-        <div>{text}</div>
-      ) : (
-        <div className="pop-button" onClick={openModal} title="Provide feedback on this content">
-          &#10068;
-        </div>
-      )}
+      {children}
       <div ref={setArrowElement} className="pop-arrow" style={styles.arrow} />
     </div>
   );
 };
 
-export default SelectionTooltip;
+export default FeedbackTooltip;

--- a/js/lib/components/feedback/tooltip.tsx
+++ b/js/lib/components/feedback/tooltip.tsx
@@ -1,14 +1,8 @@
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faQuestion } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { VirtualElement } from "@popperjs/core";
 import React, { MouseEventHandler, useState } from "react";
 import { usePopper } from "react-popper";
 
-import "../../css/feedback.scss";
-
-// load question mark SVG icon
-library.add(faQuestion);
+import "../../../css/feedback.scss";
 
 type SelectionTooltipProps = {
   reference: VirtualElement;
@@ -43,7 +37,7 @@ const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, openModa
         <div>{text}</div>
       ) : (
         <div className="pop-button" onClick={openModal} title="Provide feedback on this content">
-          <FontAwesomeIcon icon="question" />
+          &#10068;
         </div>
       )}
       <div ref={setArrowElement} className="pop-arrow" style={styles.arrow} />

--- a/js/lib/components/feedback/tooltip.tsx
+++ b/js/lib/components/feedback/tooltip.tsx
@@ -1,0 +1,54 @@
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faQuestion } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { VirtualElement } from "@popperjs/core";
+import React, { MouseEventHandler, useState } from "react";
+import { usePopper } from "react-popper";
+
+import "../../css/feedback.scss";
+
+// load question mark SVG icon
+library.add(faQuestion);
+
+type SelectionTooltipProps = {
+  reference: VirtualElement;
+  toggleModal?: () => void;
+  text?: string;
+};
+const SelectionTooltip: React.FC<SelectionTooltipProps> = ({ reference, toggleModal, text }) => {
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+  const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
+  const { styles, attributes } = usePopper(reference, popperElement, {
+    placement: "top",
+    modifiers: [
+      { name: "offset", options: { offset: [0, 8] } },
+      { name: "arrow", options: { element: arrowElement } },
+    ],
+  });
+
+  const handleTooltipClick: MouseEventHandler<HTMLDivElement> = ev => {
+    // prevent loss of selected text when user clicks on tooltip
+    ev.preventDefault();
+  };
+
+  return (
+    <div
+      ref={setPopperElement}
+      className="pop"
+      onMouseDown={handleTooltipClick}
+      style={styles.popper}
+      {...attributes.popper}
+    >
+      {text ? (
+        <div>{text}</div>
+      ) : (
+        <div className="pop-button" onClick={toggleModal} title="Provide feedback on this content">
+          <FontAwesomeIcon icon="question" />
+        </div>
+      )}
+      <div ref={setArrowElement} className="pop-arrow" style={styles.arrow} />
+    </div>
+  );
+};
+
+export default SelectionTooltip;

--- a/js/lib/components/feedback/utils.ts
+++ b/js/lib/components/feedback/utils.ts
@@ -1,0 +1,1 @@
+export const HIGHLIGHT_STORAGE_KEY = "mdbook-quiz:highlights";

--- a/js/lib/entryPoints/feedback.tsx
+++ b/js/lib/entryPoints/feedback.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import * as ReactDOM from "react-dom/client";
+import Highlighter from "web-highlighter";
+
+import SelectionRenderer from "../components/feedback/selection";
+
+export const HIGHLIGHT_STORAGE_KEY = "mdbook-quiz:highlights";
+
+let initFeedback = () => {
+  let highlighter = new Highlighter();
+  let stored = localStorage.getItem(HIGHLIGHT_STORAGE_KEY);
+  if (stored !== null) {
+    stored = JSON.parse(stored);
+  }
+
+  let div = document.createElement("div");
+  let page = document.querySelector(".page")!;
+  page.appendChild(div);
+  let root = ReactDOM.createRoot(div);
+  root.render(<SelectionRenderer highlighter={highlighter} stored={stored as unknown as any[]} />);
+};
+
+// It's important to wait for DOMContentLoaded because mdbook-quiz depends
+// on globals provided by scripts loaded via mdbook, which may be in the page
+// footer and therefore load after this script
+window.addEventListener("DOMContentLoaded", initFeedback, false);

--- a/js/lib/entryPoints/feedback.tsx
+++ b/js/lib/entryPoints/feedback.tsx
@@ -4,8 +4,7 @@ import Highlighter from "web-highlighter";
 
 import FeedbackRenderer from "../components/feedback/renderer";
 import SelectionRenderer from "../components/feedback/selection";
-
-export const HIGHLIGHT_STORAGE_KEY = "mdbook-quiz:highlights";
+import { HIGHLIGHT_STORAGE_KEY } from "../components/feedback/utils";
 
 let initFeedback = () => {
   let highlighter = new Highlighter();

--- a/js/lib/entryPoints/feedback.tsx
+++ b/js/lib/entryPoints/feedback.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as ReactDOM from "react-dom/client";
 import Highlighter from "web-highlighter";
 
+import FeedbackRenderer from "../components/feedback/renderer";
 import SelectionRenderer from "../components/feedback/selection";
 
 export const HIGHLIGHT_STORAGE_KEY = "mdbook-quiz:highlights";
@@ -9,15 +10,22 @@ export const HIGHLIGHT_STORAGE_KEY = "mdbook-quiz:highlights";
 let initFeedback = () => {
   let highlighter = new Highlighter();
   let stored = localStorage.getItem(HIGHLIGHT_STORAGE_KEY);
-  if (stored !== null) {
-    stored = JSON.parse(stored);
-  }
+  let stored_parsed = JSON.parse(stored || "[]");
 
   let div = document.createElement("div");
   let page = document.querySelector(".page")!;
   page.appendChild(div);
   let root = ReactDOM.createRoot(div);
-  root.render(<SelectionRenderer highlighter={highlighter} stored={stored as unknown as any[]} />);
+
+  root.render(
+    <>
+      {/* render tooltip over existing feedback */}
+      <FeedbackRenderer highlighter={highlighter} />
+
+      {/* render tooltip over user's current selection */}
+      <SelectionRenderer highlighter={highlighter} stored={stored_parsed as any[]} />
+    </>
+  );
 };
 
 initFeedback();

--- a/js/lib/entryPoints/feedback.tsx
+++ b/js/lib/entryPoints/feedback.tsx
@@ -20,7 +20,4 @@ let initFeedback = () => {
   root.render(<SelectionRenderer highlighter={highlighter} stored={stored as unknown as any[]} />);
 };
 
-// It's important to wait for DOMContentLoaded because mdbook-quiz depends
-// on globals provided by scripts loaded via mdbook, which may be in the page
-// footer and therefore load after this script
-window.addEventListener("DOMContentLoaded", initFeedback, false);
+initFeedback();

--- a/js/package.json
+++ b/js/package.json
@@ -12,8 +12,12 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.2",
+    "@fortawesome/free-solid-svg-icons": "^6.1.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@iarna/toml": "^2.2.5",
     "@nota-lang/esbuild-utils": "^0.3.7",
+    "@popperjs/core": "^2.11.5",
     "@testing-library/dom": "^8.14.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
@@ -25,6 +29,7 @@
     "@types/object-hash": "^2.2.1",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
+    "@types/react-modal": "^3.13.1",
     "@types/showdown": "^2.0.0",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
@@ -52,9 +57,12 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-hook-form": "^7.32.2",
+    "react-modal": "^3.15.1",
+    "react-popper": "^2.3.0",
     "react-showdown": "^2.3.1",
     "ts-json-schema-generator": "^1.0.0",
     "typescript": "4.6.4",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "web-highlighter": "^0.7.4"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -12,9 +12,6 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.1.2",
-    "@fortawesome/free-solid-svg-icons": "^6.1.2",
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "@iarna/toml": "^2.2.5",
     "@nota-lang/esbuild-utils": "^0.3.7",
     "@popperjs/core": "^2.11.5",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1,9 +1,6 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@fortawesome/fontawesome-svg-core': ^6.1.2
-  '@fortawesome/free-solid-svg-icons': ^6.1.2
-  '@fortawesome/react-fontawesome': ^0.2.0
   '@iarna/toml': ^2.2.5
   '@nota-lang/esbuild-utils': ^0.3.7
   '@popperjs/core': ^2.11.5
@@ -55,9 +52,6 @@ specifiers:
   web-highlighter: ^0.7.4
 
 devDependencies:
-  '@fortawesome/fontawesome-svg-core': 6.1.2
-  '@fortawesome/free-solid-svg-icons': 6.1.2
-  '@fortawesome/react-fontawesome': 0.2.0_nynrfkrwh56h2gmvnqypzpsozi
   '@iarna/toml': 2.2.5
   '@nota-lang/esbuild-utils': 0.3.7_esbuild@0.14.43
   '@popperjs/core': 2.11.5
@@ -532,39 +526,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@fortawesome/fontawesome-common-types/6.1.2:
-    resolution: {integrity: sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==}
-    engines: {node: '>=6'}
-    requiresBuild: true
-    dev: true
-
-  /@fortawesome/fontawesome-svg-core/6.1.2:
-    resolution: {integrity: sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==}
-    engines: {node: '>=6'}
-    requiresBuild: true
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.1.2
-    dev: true
-
-  /@fortawesome/free-solid-svg-icons/6.1.2:
-    resolution: {integrity: sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==}
-    engines: {node: '>=6'}
-    requiresBuild: true
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.1.2
-    dev: true
-
-  /@fortawesome/react-fontawesome/0.2.0_nynrfkrwh56h2gmvnqypzpsozi:
-    resolution: {integrity: sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==}
-    peerDependencies:
-      '@fortawesome/fontawesome-svg-core': ~1 || ~6
-      react: '>=16.3'
-    dependencies:
-      '@fortawesome/fontawesome-svg-core': 6.1.2
-      prop-types: 15.8.1
-      react: 18.1.0
     dev: true
 
   /@humanwhocodes/config-array/0.9.5:

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1,8 +1,12 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@fortawesome/fontawesome-svg-core': ^6.1.2
+  '@fortawesome/free-solid-svg-icons': ^6.1.2
+  '@fortawesome/react-fontawesome': ^0.2.0
   '@iarna/toml': ^2.2.5
   '@nota-lang/esbuild-utils': ^0.3.7
+  '@popperjs/core': ^2.11.5
   '@testing-library/dom': ^8.14.0
   '@testing-library/jest-dom': ^5.16.4
   '@testing-library/react': ^13.3.0
@@ -14,6 +18,7 @@ specifiers:
   '@types/object-hash': ^2.2.1
   '@types/react': ^18.0.9
   '@types/react-dom': ^18.0.5
+  '@types/react-modal': ^3.13.1
   '@types/showdown': ^2.0.0
   '@types/uuid': ^8.3.4
   '@typescript-eslint/eslint-plugin': ^5.26.0
@@ -41,14 +46,21 @@ specifiers:
   react: ^18.1.0
   react-dom: ^18.1.0
   react-hook-form: ^7.32.2
+  react-modal: ^3.15.1
+  react-popper: ^2.3.0
   react-showdown: ^2.3.1
   ts-json-schema-generator: ^1.0.0
   typescript: 4.6.4
   uuid: ^8.3.2
+  web-highlighter: ^0.7.4
 
 devDependencies:
+  '@fortawesome/fontawesome-svg-core': 6.1.2
+  '@fortawesome/free-solid-svg-icons': 6.1.2
+  '@fortawesome/react-fontawesome': 0.2.0_nynrfkrwh56h2gmvnqypzpsozi
   '@iarna/toml': 2.2.5
   '@nota-lang/esbuild-utils': 0.3.7_esbuild@0.14.43
+  '@popperjs/core': 2.11.5
   '@testing-library/dom': 8.14.0
   '@testing-library/jest-dom': 5.16.4
   '@testing-library/react': 13.3.0_ef5jwxihqo6n7gxfmzogljlgcm
@@ -60,6 +72,7 @@ devDependencies:
   '@types/object-hash': 2.2.1
   '@types/react': 18.0.12
   '@types/react-dom': 18.0.5
+  '@types/react-modal': 3.13.1
   '@types/showdown': 2.0.0
   '@types/uuid': 8.3.4
   '@typescript-eslint/eslint-plugin': 5.27.1_bnfefdnvqpcyokeggdz5sotnli
@@ -87,10 +100,13 @@ devDependencies:
   react: 18.1.0
   react-dom: 18.1.0_react@18.1.0
   react-hook-form: 7.32.2_react@18.1.0
+  react-modal: 3.15.1_ef5jwxihqo6n7gxfmzogljlgcm
+  react-popper: 2.3.0_42yiot2n2wjamynwfzzmd7tk3i
   react-showdown: 2.3.1_react@18.1.0
   ts-json-schema-generator: 1.0.0
   typescript: 4.6.4
   uuid: 8.3.2
+  web-highlighter: 0.7.4
 
 packages:
 
@@ -518,6 +534,39 @@ packages:
       - supports-color
     dev: true
 
+  /@fortawesome/fontawesome-common-types/6.1.2:
+    resolution: {integrity: sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dev: true
+
+  /@fortawesome/fontawesome-svg-core/6.1.2:
+    resolution: {integrity: sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.1.2
+    dev: true
+
+  /@fortawesome/free-solid-svg-icons/6.1.2:
+    resolution: {integrity: sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.1.2
+    dev: true
+
+  /@fortawesome/react-fontawesome/0.2.0_nynrfkrwh56h2gmvnqypzpsozi:
+    resolution: {integrity: sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==}
+    peerDependencies:
+      '@fortawesome/fontawesome-svg-core': ~1 || ~6
+      react: '>=16.3'
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 6.1.2
+      prop-types: 15.8.1
+      react: 18.1.0
+    dev: true
+
   /@humanwhocodes/config-array/0.9.5:
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
@@ -888,6 +937,10 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@popperjs/core/2.11.5:
+    resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
+    dev: true
+
   /@sinclair/typebox/0.23.5:
     resolution: {integrity: sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==}
     dev: true
@@ -1089,6 +1142,12 @@ packages:
 
   /@types/react-dom/18.0.5:
     resolution: {integrity: sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==}
+    dependencies:
+      '@types/react': 18.0.12
+    dev: true
+
+  /@types/react-modal/3.13.1:
+    resolution: {integrity: sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==}
     dependencies:
       '@types/react': 18.0.12
     dev: true
@@ -2741,6 +2800,10 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+    dev: true
+
+  /exenv/1.2.2:
+    resolution: {integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==}
     dev: true
 
   /exit/0.1.2:
@@ -5023,6 +5086,10 @@ packages:
       scheduler: 0.22.0
     dev: true
 
+  /react-fast-compare/3.2.0:
+    resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
+    dev: true
+
   /react-hook-form/7.32.2_react@18.1.0:
     resolution: {integrity: sha512-F1A6n762xaRhvtQH5SkQQhMr19cCkHZYesTcKJJeNmrphiZp/cYFTIzC05FnQry0SspM54oPJ9tXFXlzya8VNQ==}
     engines: {node: '>=12.22.0'}
@@ -5042,6 +5109,39 @@ packages:
 
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
+
+  /react-lifecycles-compat/3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+    dev: true
+
+  /react-modal/3.15.1_ef5jwxihqo6n7gxfmzogljlgcm:
+    resolution: {integrity: sha512-duB9bxOaYg7Zt6TMFldIFxQRtSP+Dg3F1ZX3FXxSUn+3tZZ/9JCgeAQKDg7rhZSAqopq8TFRw3yIbnx77gyFTw==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
+      react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
+    dependencies:
+      exenv: 1.2.2
+      prop-types: 15.8.1
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      react-lifecycles-compat: 3.0.4
+      warning: 4.0.3
+    dev: true
+
+  /react-popper/2.3.0_42yiot2n2wjamynwfzzmd7tk3i:
+    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
+    dependencies:
+      '@popperjs/core': 2.11.5
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      react-fast-compare: 3.2.0
+      warning: 4.0.3
     dev: true
 
   /react-showdown/2.3.1_react@18.1.0:
@@ -5904,6 +6004,16 @@ packages:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
       makeerror: 1.0.12
+    dev: true
+
+  /warning/4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /web-highlighter/0.7.4:
+    resolution: {integrity: sha512-07mWw6ib+Abcr/fuKEWYPy1Y0MsCOz6yUUVw9xMpyt5UzyXWtSlcwzy2YqnccCP/LjtM9MZHQSo3dbGJII8h6w==}
     dev: true
 
   /webidl-conversions/3.0.1:

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -40,6 +40,10 @@ pub struct QuizConfig {
   /// DO NOT USE
   consent: Option<bool>,
 
+  /// If true, allow users to give feedback on book content in the form of
+  /// highlights with comments.
+  feedback: Option<bool>,
+
   dev_mode: bool,
 }
 
@@ -62,12 +66,19 @@ impl QuizProcessorRef {
     let target_dir = self.src_dir.join("mdbook-quiz");
     fs::create_dir_all(&target_dir)?;
 
-    let mut files = vec!["embed.js", "embed.css", "feedback.js", "feedback.css"];
+    let mut files = vec!["embed.js", "embed.css"];
     if self.config.dev_mode {
-      files.extend(["embed.js.map", "embed.css.map", "feedback.js.map", "feedback.css.map"]);
+      files.extend(["embed.js.map", "embed.css.map"]);
     }
     if let Some(true) = self.config.consent {
       files.extend(["consent.js", "consent.css"]);
+    }
+    if let Some(true) = self.config.feedback {
+      files.extend(["feedback.js", "feedback.css"]);
+
+      if self.config.dev_mode {
+        files.extend(["feedback.js.map", "feedback.css.map"]);
+      }
     }
 
     for file in &files {
@@ -215,6 +226,7 @@ impl Preprocessor for QuizProcessor {
       commit_hash,
       fullscreen: parse_bool("fullscreen"),
       consent: parse_bool("consent"),
+      feedback: parse_bool("feedback"),
       validate: parse_bool("validate"),
       cache_answers: parse_bool("cache-answers"),
       dev_mode: env::var("QUIZ_DEV_MODE").is_ok(),

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -62,9 +62,9 @@ impl QuizProcessorRef {
     let target_dir = self.src_dir.join("mdbook-quiz");
     fs::create_dir_all(&target_dir)?;
 
-    let mut files = vec!["embed.js", "embed.css"];
+    let mut files = vec!["embed.js", "embed.css", "feedback.js", "feedback.css"];
     if self.config.dev_mode {
-      files.extend(["embed.js.map", "embed.css.map"]);
+      files.extend(["embed.js.map", "embed.css.map", "feedback.js.map", "feedback.css.map"]);
     }
     if let Some(true) = self.config.consent {
       files.extend(["consent.js", "consent.css"]);


### PR DESCRIPTION
## Overview
This PR adds a (currently) naive system for adding and persisting feedback on book content.

## Video example
https://user-images.githubusercontent.com/40175891/182223568-45bab38c-b625-47a6-b2b4-fc32dc67fc80.mp4

## Implementation
The `feedback.tsx` entrypoint instantiates a `SelectionRenderer` which does a couple things:
1. Renders any feedback currently stored in local storage as a yellow highlight
2. Tracks the user's current selection range (what they're highlighting in the document) and renders a tooltip over the selection
    - The tooltip component is found in `tooltip.tsx`
    - Clicking on the question mark icon in the tooltip triggers a modal for giving feedback (component in `modal.tsx`)
3. Stores new feedback in local storage when created
4. Displays a tooltip over existing feedback highlights when they're hovered over

Serialization of feedback ranges is done by [web-highlighter](https://github.com/alienzhou/web-highlighter). Their serialization strategy does not seem well-suited for dynamic content, something that will need to be fixed for a production-ready version of this feature.

## Additional considerations
- This PR does not currently send feedback to the telemetry/results server
- This PR does not allow users to delete feedback (is this something that should be added?)

## Todo
- [x] Replace hard-coded colors with theme variables
- [x] Factor out `SelectionRenderer` into multiple, simpler components
- [x] Add ability to delete a highlight
- [ ] Add integration test
- [ ] Fix issue where not adding feedback causes the tooltip to render a question mark